### PR TITLE
Added original Vets Visits forgot password designs

### DIFF
--- a/app/views/mfa/scenarios.html
+++ b/app/views/mfa/scenarios.html
@@ -174,7 +174,7 @@ href: "javascript:history.back()"
           </div>
           <div class="govuk-card__actions">
             <ul class="govuk-list govuk-!-mb-r0">
-              <li><a href="/mfa/vets/crn-sign-in" class="govuk-link--no-visited-state">View</a></li>
+              <li><a href="/vets/crn-sign-in" class="govuk-link--no-visited-state">View</a></li>
             </ul>
           </div>
         </div>

--- a/app/views/vets/crn-sign-in.html
+++ b/app/views/vets/crn-sign-in.html
@@ -1,0 +1,85 @@
+{% extends "layout-signed-out.html" %}
+
+{% set serviceName = "Vets visits" %}
+
+{% set title = "Sign in to vets visits" %}
+
+{% block pageTitle %}
+  {{title}} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  
+{% endblock %}
+
+{% block content %}
+
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">
+        {{ title }}
+      </h1>
+  
+  
+      <form action="verify">
+  
+  <div class="govuk-form-group">
+    <label class="govuk-label" for="crn">
+      Customer reference number (CRN)
+    </label>
+  
+    
+    
+    <div id="crn-hint" class="govuk-hint">
+      This is the 10 digit number emailed to you when you created your RPA account
+    </div>
+  
+  <input class="govuk-input govuk-!-width-full-width" id="crn" name="crn" type="text" aria-describedby="crn-hint">
+  </div>
+  
+  
+      
+  
+  <div class="govuk-form-group">
+    <label class="govuk-label" for="password--">
+      Password
+    </label>
+  
+  <input class="govuk-input govuk-!-width-full-width" id="password--" name="password--" type="password">
+  </div>
+  
+  
+      
+  
+    
+      
+    
+  
+  <a href="verify" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+    Sign in
+  </a>
+
+</form>
+  
+  
+      <p><a href="/vets/forgot-password">I forgot my password</a></p>
+      <details class="govuk-details" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        Other problems signing in
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      Started creating a new password and received the security code by email - <a href="#">enter it here</a><br>
+  
+        Lost your customer reference number (CRN), call 03000 200 301.
+    </div>
+  </details>
+  
+  
+     
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/vets/forgot-password-code.html
+++ b/app/views/vets/forgot-password-code.html
@@ -1,0 +1,59 @@
+{% extends "layout.html" %}
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{% block pageTitle %}
+  Reset your Rural Payments account password
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        Reset your Rural Payments account password
+      </h1>
+
+      <p>
+        We will send you a code by email allowing you to reset the password associated with your Rural Payments account.
+      </p>
+      
+      {{ govukWarningText({
+        text: "If you use a browser to access your email, you may need to open a new window or tab to see the code.",
+        iconFallbackText: "Warning"
+      }) }}
+
+      {{ govukInput({
+        label: {
+          text: "Enter your RPA customer reference number (CRN)",
+          isPageHeading: false
+        },
+        hint: {
+          text: 'Your customer reference number is the 10-digit number emailed to you when you created your RPA account'
+        },
+        id: 'crn',
+        name: 'crn'
+      }) }}
+
+      {{ govukInput({
+        label: {
+          text: "Enter your email address",
+          isPageHeading: false
+        },
+        id: 'email',
+        name: 'email',
+        type: 'email'
+      }) }}
+      
+      {{ govukButton({
+        text: "Continue",
+        href: '/vets/forgot-password'
+      }) }}
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/vets/forgot-password-complete.html
+++ b/app/views/vets/forgot-password-complete.html
@@ -1,0 +1,36 @@
+{% extends "layout.html" %}
+
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block pageTitle %}
+  Rural Payments password updated
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+     {{ govukPanel({
+        titleText: "Password update complete",
+        html: ""
+      }) }}
+
+      <p>
+        We have updated your Rural Payments password.
+      </p>
+
+      <h2 class="govuk-heading-m">What happens next</h2>
+      <p>Now that we have updated your password you can continue on to the service.</p>
+      
+      {{ govukButton({
+        text: "Continue",
+        href: '#'
+      }) }}
+
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/vets/forgot-password.html
+++ b/app/views/vets/forgot-password.html
@@ -1,0 +1,80 @@
+{% extends "layout.html" %}
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{% block pageTitle %}
+  Change your Rural Payments account password
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        Change your Rural Payments account password
+      </h1>
+
+      <p>
+        Your RPA customer reference number is: <strong>0123456789</strong><br>
+        We have sent a code to: <strong>your@email.com</strong>
+      </p>
+      
+      {{ govukWarningText({
+        text: "If you use a browser to access your email, you may need to open a new window or tab to see the code.",
+        iconFallbackText: "Warning"
+      }) }}
+
+      <h2 class="govuk-heading-m">Now update your password</h2>
+
+      <p>
+        Once you have received your code enter it here along with your new password.
+      </p>
+
+      {{ govukInput({
+        label: {
+          text: "Confirmation code",
+          isPageHeading: false
+        },
+        id: 'crn',
+        name: 'crn',
+        type: 'text'
+      }) }}      
+
+      {{ govukDetails({
+        summaryText: "I have not received the email",
+        html: "<p>The email may take a few minutes to arrive. If you still have not got the code, you can try <a href='#' class='govuk-link'>resending</a> it.</p><p>If your RPA customer reference number or email address are wrong you will need to start again.</p>"
+      }) }}
+
+      {{ govukInput({
+        label: {
+          text: "Your new password",
+          isPageHeading: false
+        },
+        id: 'password',
+        name: 'password',
+        type: 'password'
+      }) }}
+
+      {{ govukInput({
+        label: {
+          text: "Confirm your new password",
+          isPageHeading: false
+        },
+        id: 'password-confirmation',
+        name: 'password-confirmation',
+        type: 'password'
+      }) }}
+      
+      {{ govukButton({
+        text: "Save and continue",
+        href: '/vets/forgot-password-complete'
+      }) }}
+
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
@devansXD as requested, these are our original designs for the Vets' Visits forgot password screens in Defra Identity. For consistency I've re-used your `crn-sign-in` page rather than the original design, though I haven't checked whether there were any differences.

I've added them under the `/vets` folder, rather than `/mfa/vets` as they're not really to do with MFA, but they can be moved if needs be.